### PR TITLE
Fix some tools safe strings

### DIFF
--- a/tools/get_range.ml
+++ b/tools/get_range.ml
@@ -65,14 +65,14 @@ let _ =
         
         let segment = kilobytes 10 in
         let bufferlen = Int64.to_int segment in
-        let buffer = String.create bufferlen in
+        let buffer = Bytes.create bufferlen in
         let rec iter begin_pos end_pos =
           let len = end_pos -- begin_pos in
           if len > zero then
             let len64 = min segment len in
             let len = Int64.to_int len64 in
             Unix32.read t begin_pos buffer 0 len;
-            let encoded = Base64.encode_substring buffer 0 len in
+            let encoded = Base64.encode_substring (Bytes.to_string buffer) 0 len in
             Printf.printf "[SEGMENT %s %Ld %d %d]\n" file_num begin_pos len (
               String.length encoded);
             output_string Pervasives.stdout encoded;
@@ -91,14 +91,14 @@ let _ =
         
         let segment = kilobytes 10 in
         let bufferlen = Int64.to_int segment in
-        let buffer = String.create bufferlen in
+        let buffer = Bytes.create bufferlen in
         let rec iter begin_pos end_pos =
           let len = end_pos -- begin_pos in
           if len > zero then
             let len64 = min segment len in
             let len = Int64.to_int len64 in
             Unix32.read t begin_pos buffer 0 len;
-            let encoded = String.sub buffer 0 len in
+            let encoded = String.sub (Bytes.to_string buffer) 0 len in
             Printf.printf "[SEGMENT 8bits %s %Ld %d %d]\n" file_num begin_pos len (
               String.length encoded);
             output_string Pervasives.stdout encoded;

--- a/tools/mld_hash.ml
+++ b/tools/mld_hash.ml
@@ -56,11 +56,11 @@ let rec tiger_of_array array pos block =
   else
   let d1 = tiger_of_array array pos (block/2) in
   let d2 = tiger_of_array array (pos+block/2) (block/2) in
-  let s = String.create (1 + Tiger.length * 2) in
+  let s = Bytes.create (1 + Tiger.length * 2) in
   s.[0] <- '\001';
   String.blit (TigerTree.direct_to_string d1) 0 s 1 Tiger.length;
   String.blit (TigerTree.direct_to_string d2) 0 s (1+Tiger.length) Tiger.length;
-  let t = Tiger.string s in
+  let t = Tiger.string (Bytes.to_string s) in
   let t = TigerTree.direct_of_string (Tiger.direct_to_string t) in
   t
 
@@ -142,7 +142,7 @@ let ed2k_hash_file fd file_size =
   let md4 = if nchunk_hashes = 0 then
       Md4.digest_subfile fd zero file_size        
     else
-    let chunks = String.create (nchunks*16) in
+    let chunks = Bytes.create (nchunks*16) in
     for i = 0 to nchunks - 1 do
       let begin_pos = edk_block_size ** (Int64.of_int i) in
       let end_pos = begin_pos ++ edk_block_size in
@@ -154,7 +154,7 @@ let ed2k_hash_file fd file_size =
       let md4 = Md4.direct_to_string md4 in
       String.blit md4 0 chunks (i*16) 16;
     done;
-    Md4.string chunks
+    Md4.string (Bytes.to_string chunks)
   in
   md4
 
@@ -272,9 +272,9 @@ let sig2dat_hash_filename filename =
   let file_size = Unix32.getsize64 fd in
   let len64 = min 307200L file_size in
   let len = Int64.to_int len64 in
-  let s = String.create len in
+  let s = Bytes.create len in
   Unix32.read fd zero s 0 len;
-  let md5ext = Md5Ext.string s in
+  let md5ext = Md5Ext.string (Bytes.to_string s) in
   lprintf "sig2dat://|File: %s|Length: %Ld Bytes|UUHash: %s|/\n"
     (Url.encode (Filename.basename filename)) file_size (Md5Ext.to_string md5ext);
   lprintf "    Hash: %s\n" (Md5Ext.to_hexa_case false md5ext);
@@ -324,12 +324,12 @@ let check_external_functions file_size =
     
     ] in
   
-  let test_string = String.create test_string_len in
+  let test_string = Bytes.create test_string_len in
   let rec iter pos =
     if pos < test_string_len then
       let end_pos = min test_string_len (2*pos) in
       let len = end_pos - pos in        
-      String.blit test_string 0 test_string pos len;
+      String.blit (Bytes.to_string test_string) 0 test_string pos len;
       iter end_pos
   in
   
@@ -369,7 +369,7 @@ let check_external_functions file_size =
 
         lprintf "Filling file\n";
         List.iter (fun (pos, len) ->
-            Unix32.write file pos test_string 0 len;                
+            Unix32.write file pos (Bytes.to_string test_string) 0 len;                
         ) waves;
         
         lprintf "Computing ed2k hash\n";
@@ -414,8 +414,8 @@ let diff_chunk args =
   if end_pos -- begin_pos > max_diff_size then
     failwith (Printf.sprintf "Cannot diff chunk > %Ld bytes" max_diff_size);
   let len = Int64.to_int (end_pos -- begin_pos) in
-  let s1 = String.create len in
-  let s2 = String.create len in
+  let s1 = Bytes.create len in
+  let s2 = Bytes.create len in
   let fd1 = Unix32.create_ro filename1 in
   let fd2 = Unix32.create_ro filename2 in
   Unix32.read fd1 begin_pos s1 0 len;
@@ -423,7 +423,7 @@ let diff_chunk args =
   
   let rec iter_in old_pos pos =
     if pos < len then 
-      if s1.[pos] <> s2.[pos] then begin
+      if (Bytes.to_string s1).[pos] <> (Bytes.to_string s2).[pos] then begin
           lprintf "  common %Ld-%Ld %d\n"
             (begin_pos ++ Int64.of_int old_pos)
           (begin_pos ++ Int64.of_int (pos-1))
@@ -439,7 +439,7 @@ let diff_chunk args =
       
   and iter_out old_pos pos =
     if pos < len then
-      if s1.[pos] <> s2.[pos] then 
+      if (Bytes.to_string s1).[pos] <> (Bytes.to_string s2).[pos] then 
         iter_out old_pos (pos+1) 
       else
         begin

--- a/tools/svg_converter.ml
+++ b/tools/svg_converter.ml
@@ -19,17 +19,16 @@
 
 
 open Filename2
-open Zlib
 
 let load_svg file =
   Printf.printf "Converting file %s\n" file;
   flush stdout;
   let ic = open_in_bin file in
   let len = in_channel_length ic in
-  let buf = String.create len in
+  let buf = Bytes.create len in
   really_input ic buf 0 len;
   close_in ic;
-  let bufz = compress_string buf in
+  let bufz = Zlib2.compress_string (Bytes.to_string buf) in
   let basename = basename file in
   let extension = last_extension basename in
   let dirname = String.sub file 0 (String.length file - String.length basename) in


### PR DESCRIPTION
For get_range.ml, mld_hash.ml and svg_converter.ml:
- Fix deprecated String.create alias of Bytes.create
- Convert Bytes.to_string where needed